### PR TITLE
Travis integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+
+python:
+  - "2.7_with_system_site_packages"
+
+before_install:
+  - sudo apt-get update
+  - sudo apt-get install python-gobject-2
+
+script:
+  - eval `dbus-launch --sh-syntax` && cd test && python test_vedbus.py -v

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 velib_python
 ============
+
+[![Build Status](https://travis-ci.org/quinox/velib_python.svg?branch=travis)](https://travis-ci.org/quinox/velib_python)
+
 This is the general python library within Victron. It contains code that is related to D-Bus and the Color
 Control GX. See http://www.victronenergy.com/panel-systems-remote-monitoring/colorcontrol/ for more
 infomation about that panel.


### PR DESCRIPTION
As discussed with @mpvader : Automatic running of testcases based on Travis.

Preview: https://travis-ci.org/quinox/velib_python/builds/119823327

How to use:
* Visit https://travis-ci.org/
* Click "Sign in with GitHub" on the top right, grant API permissions to Travis
* Inside Travis, enable CI for the velib_python project
* Merge this PR with an updated badge URL: https://travis-ci.org/victronenergy/velib_python.svg?branch=master