### PR TITLE
Fix race in handleChangedSetting when setting is not yet initialized

### DIFF
--- a/settingsdevice.py
+++ b/settingsdevice.py
@@ -93,7 +93,7 @@ class SettingsDevice(object):
 		return busitem
 
 	def handleChangedSetting(self, setting, servicename, path, changes):
-		oldvalue = self._values[setting]
+		oldvalue = self._values[setting] if setting in self._values else None
 		self._values[setting] = changes['Value']
 
 		if self._eventCallback is None:


### PR DESCRIPTION
This fixes `KeyErrors` when `handleChangedSetting` gets called early, before `self._settings[setting]` is initialized. I think this happens because I initialize the `SettingsDevice` when the mainloop is already running.
  
Symptom:
- `addSetting` gets called on line 59
- `addSetting` registers change-callback on line 91
- change-callback (`handleChangedSetting`) gets called right away
- `handleChangedSetting` raises `KeyError` on line 96 because `self._values[setting]` is not yet defined
- `self._values[setting]` would normally been initialized on line 61 after `addSetting` returns